### PR TITLE
Renaming all auth-api to dbus-api

### DIFF
--- a/lib/dbus_api_service.rb
+++ b/lib/dbus_api_service.rb
@@ -6,7 +6,7 @@ class DBusApiService < Sinatra::Base
   DEFAULT_USER_ATTRIBUTES = %w(mail givenname sn displayname domainname).freeze
 
   set :bind, "0.0.0.0"
-  set :port, ENV.fetch("HTTPD_AUTH_API_SERVICE_PORT", 8080)
+  set :port, ENV.fetch("HTTPD_DBUS_API_SERVICE_PORT", 8080)
 
   get "/api/user_attrs/:userid", :provides => 'json' do
     attrs_needed = params[:attributes].nil? ? DEFAULT_USER_ATTRIBUTES : params[:attributes].split(',')


### PR DESCRIPTION
- Reflecting the new repo ManageIQ/dbus_api_service
- Container environment port definition changing from
  HTTPD_AUTH_API_SERVICE_PORT to HTTPD_DBUS_API_SERVICE_PORT