### PR TITLE
As of Sinatra 2.0.8+: response.body now contains the request

### DIFF
--- a/spec/dbus_api_service_spec.rb
+++ b/spec/dbus_api_service_spec.rb
@@ -23,7 +23,7 @@ describe DBusApiService do
 
   def assert_not_found
     expect(last_response).to_not be_ok
-    expect(last_response.body).to include "Not Found"
+    expect(last_response.status).to eql 404
   end
 
   def assert_response(expected)


### PR DESCRIPTION
EDIT:  Current master is broken since sinatra 2.0.8 was released, roughly January 2020.  This PR fixes it by using a more reliable mechanism for checking for "not found" using the http status code.


Sinatra 2.0.8 and 2.0.7 both have status: 404, it's more reliable to check

Sinatra 2.0.7: body is the resulting html with Not Found, status is 404:

```
 #<Rack::MockResponse:0x00007ff3382ea198 @original_headers={"Content-Type"=>"text/html;charset=utf-8", "X-Cascade"=>"pass", "Content-Length"=>"18", "X-XSS-Protection"=>"1; mode=block", "X-Content-Type-Options"=>"nosniff", "X-Frame-Options"=>"SAMEORIGIN"}, @errors="", @cookies={}, @status=404, @headers={"Content-Type"=>"text/html;charset=utf-8", "X-Cascade"=>"pass", "Content-Length"=>"18", "X-XSS-Protection"=>"1; mode=block", "X-Content-Type-Options"=>"nosniff", "X-Frame-Options"=>"SAMEORIGIN"}, @writer=#<Method: Rack::MockResponse(Rack::Response::Helpers)#append>, @block=nil, @body=["<h1>Not Found</h1>"], @buffered=true, @length=18>
 "<h1>Not Found</h1>"
```
Sinatra 2.0.8+: body is the request, status is 404

```
 #<Rack::MockResponse:0x00007f95c431b6c0 @original_headers={"X-Cascade"=>"pass", "Content-Type"=>"text/html;charset=utf-8", "Content-Length"=>"5", "X-XSS-Protection"=>"1; mode=block", "X-Content-Type-Options"=>"nosniff", "X-Frame-Options"=>"SAMEORIGIN"}, @errors="", @cookies={}, @status=404, @headers={"X-Cascade"=>"pass", "Content-Type"=>"text/html;charset=utf-8", "Content-Length"=>"5", "X-XSS-Protection"=>"1; mode=block", "X-Content-Type-Options"=>"nosniff", "X-Frame-Options"=>"SAMEORIGIN"}, @writer=#<Method: Rack::MockResponse(Rack::Response::Helpers)#append>, @block=nil, @body=["GET /"], @buffered=true, @length=5>
 "GET /"
```