### PR TITLE
remove sudo: false from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 rvm:
 - 2.5.8
 - 2.6.6
-sudo: false
 cache: bundler
 after_script: bundle exec codeclimate-test-reporter
 matrix:


### PR DESCRIPTION
we no longer need `sudo: false` per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration