### PR TITLE
remove deprecated codeclimate-test-reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ rvm:
 - 2.5.8
 - 2.6.6
 cache: bundler
-after_script: bundle exec codeclimate-test-reporter
+before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- ./cc-test-reporter before-build
+after_script:
+- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 matrix:
   allow_failures:
   - rvm: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :test do
   gem "rspec", "~>3.6"
 
   # Coverage
-  gem "codeclimate-test-reporter"
   gem "simplecov"
 end
 


### PR DESCRIPTION
```
Post-install message from codeclimate-test-reporter:

  Code Climate's codeclimate-test-reporter gem has been deprecated in favor of
  our language-agnostic unified test reporter. The new test reporter is faster,
  distributed as a static binary so dependency conflicts never occur, and
  supports parallelized CI builds & multi-language CI configurations.

  Please visit https://docs.codeclimate.com/v1.0/docs/configuring-test-coverage
  for help setting up your CI process with our new test reporter.
```

it depends on the addition of the token re: https://github.com/ManageIQ/azure-armrest/pull/403#issuecomment-754050779

@miq-bot add_label dependencies, test, cleanup 
@miq-bot assign @Fryguy 